### PR TITLE
removing CVE-2017-5929 in ch.qos.logback:logback-classic:1.1.11

### DIFF
--- a/crank4j-connector/pom.xml
+++ b/crank4j-connector/pom.xml
@@ -22,7 +22,7 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.1.11</version>
+			<version>1.2.0</version>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
### updated to ch.qos.logback:logback-classic:1.2.0, verification result:
> build passed but you don't seem to have any test! good luck!

### CVE details
[CVE-2017-5929](https://nvd.nist.gov/vuln/detail/CVE-2017-5929) - CRITICAL 7.5/9.8
>QOS.ch Logback before 1.2.0 has a serialization vulnerability affecting the SocketServer and ServerSocketReceiver components.